### PR TITLE
Campaigns contracts additional tests and some api fixes

### DIFF
--- a/contracts/campaign/src/test.rs
+++ b/contracts/campaign/src/test.rs
@@ -3,7 +3,7 @@ extern crate std;
 use super::*;
 use crate::{localcoin, Campaign, CampaignClient};
 
-use soroban_sdk::{testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, Symbol, Address, Env, IntoVal};
+use soroban_sdk::{testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, Symbol, Val, Address, Env, IntoVal};
 
 fn deploy_campaign<'a>(env: &Env, name:String, description:String, no_of_recipients:u32, token_address:Address, creator:Address) -> (Address, CampaignClient<'a>) {
     let contract_id = env.register_contract(None, Campaign);
@@ -26,10 +26,12 @@ fn test_set_campaign_info() {
 
     let (_, campaign) = deploy_campaign(&env, name.clone(), description.clone(), no_of_recipients.clone(), token_address.clone(), creator.clone());
 
-    let mut campaign_info: Vec<Val> = Vec::new(&env);
-    campaign_info.push_back(name.to_val());
-    campaign_info.push_back(description.to_val());
-    campaign_info.push_back(no_of_recipients.into());
+    let mut campaign_info: Map<String, Val> = Map::new(&env);
+    campaign_info.set(String::from_str(&env, "name"), name.to_val());
+    campaign_info.set(String::from_str(&env, "description"), description.to_val());
+    campaign_info.set(String::from_str(&env, "no_of_recipients"), no_of_recipients.into());
+    campaign_info.set(String::from_str(&env, "token_address"), token_address.to_val());
+    campaign_info.set(String::from_str(&env, "creator"), creator.to_val());
     
     // assert campaign info
     assert_eq!(campaign.get_campaign_info(), campaign_info);

--- a/contracts/campaign_management/src/lib.rs
+++ b/contracts/campaign_management/src/lib.rs
@@ -29,7 +29,7 @@ pub struct CampaignDetail {
     pub campaign: Address,
     pub token: Address,
     pub token_minted: i128,
-    pub info: Vec<Val>
+    pub info: Map<String, Val>
 }
 
 #[derive(Clone)]
@@ -82,7 +82,7 @@ impl CampaignManagement {
             let user_registry_client = user_registry::Client::new(&env, &user_registry_addr);
 
             let valid_tokens = user_registry_client.get_available_tokens();
-            if !valid_tokens.contains(token_address.clone()) {
+            if !(valid_tokens.contains(token_address.clone())) {
                 panic!("Invalid token passed in param.")
             }
 
@@ -131,10 +131,10 @@ impl CampaignManagement {
             let key = DataKeys:: CreatorCampaigns(creator.clone());
             let mut creator_campaigns = Self::get_creator_campaigns(env.clone(), creator.clone());
 
-            let mut new_campaign_info: Vec<Val> = Vec::new(&env);
-            new_campaign_info.push_back(name.to_val());
-            new_campaign_info.push_back(description.to_val());
-            new_campaign_info.push_back(no_of_recipients.into());
+            let mut new_campaign_info: Map<String, Val> = Map::new(&env);
+            new_campaign_info.set(String::from_str(&env, "name"), name.to_val());
+            new_campaign_info.set(String::from_str(&env, "description"), description.to_val());
+            new_campaign_info.set(String::from_str(&env, "no_of_recipients"), no_of_recipients.into());
 
             let campaign_value = CampaignDetail {
                 campaign: campaign_contract_addr,
@@ -152,23 +152,26 @@ impl CampaignManagement {
         // transaction should be sent from 'from' addesss
         from.require_auth();
 
+        if amount <= 0 {
+            panic!("Amount cannot be equal or less than zero.")
+        }
         let user_registry = Self::get_user_registry(env.clone());
         let user_registry_client = user_registry::Client::new(&env, &user_registry);
 
         let valid_tokens = user_registry_client.get_available_tokens();
-        if !valid_tokens.contains(token_address.clone()) {
+        if !(valid_tokens.contains(token_address.clone())) {
             panic!("Invalid token passed in param.")
         }
 
         let merchants = user_registry_client.get_verified_merchants();
-        if !merchants.contains(&from) {
+        if !(merchants.contains(&from)) {
             panic!("Caller not merchant.")
         }
 
         let token_client = localcoin::Client::new(&env, &token_address);
         // verify balance of merchant
         let balance = token_client.balance(&from);
-        if !balance >= amount {
+        if !(balance >= amount) {
             panic!("Insufficient token for settelment.")
         }
 
@@ -182,7 +185,7 @@ impl CampaignManagement {
         let current_contract_address = env.current_contract_address();
 
         let stable_coin_balance = stable_coin_client.balance(&current_contract_address);
-        if !stable_coin_balance >= amount {
+        if !(stable_coin_balance >= amount) {
             panic!("Insufficient stable coin in camapign management for settelment.")
         }
         // transfer stable coin to super admin

--- a/contracts/campaign_management/src/test.rs
+++ b/contracts/campaign_management/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 extern crate std;
 use super::*;
-use crate::{user_registry, CampaignManagement, CampaignManagementClient};
+use crate::{user_registry, campaign_contract, localcoin, CampaignManagement, CampaignManagementClient};
 use crate::user_registry::Client;
 
 use soroban_sdk::{testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, Symbol, Address, Env, IntoVal};
@@ -10,13 +10,6 @@ mod issuance_management {
     soroban_sdk::contractimport!(
         file =
             "../issuance_management/target/wasm32-unknown-unknown/release/issuance_management.wasm"
-    );
-}
-
-mod localcoin {
-    soroban_sdk::contractimport!(
-        file =
-            "../localcoin/target/wasm32-unknown-unknown/release/localcoin.wasm"
     );
 }
 
@@ -62,6 +55,66 @@ fn test_double_initialize() {
 }
 
 #[test]
+fn test_set_stable_coin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let super_admin = Address::generate(&env);
+    let stable_coin = Address::generate(&env);
+
+    let (user_registry_address, _) = deploy_user_registry(&env, &super_admin);
+    let (campaign_management_address, campaign_management) = deploy_campaign_management(&env, &user_registry_address);
+
+    // set stable coin address
+    campaign_management.set_stable_coin_address(&stable_coin);
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            super_admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    campaign_management_address.clone(),
+                    Symbol::new(&env, "set_stable_coin_address"),
+                    (&stable_coin, ).into_val(&env),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_set_stable_coin_fron_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let super_admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let stable_coin = Address::generate(&env);
+
+    let (user_registry_address, _) = deploy_user_registry(&env, &super_admin);
+    let (campaign_management_address, campaign_management) = deploy_campaign_management(&env, &user_registry_address);
+
+    // set stable coin address
+    campaign_management.set_stable_coin_address(&stable_coin);
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            non_admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    campaign_management_address.clone(),
+                    Symbol::new(&env, "set_stable_coin_address"),
+                    (&stable_coin, ).into_val(&env),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+}
+
+#[test]
 fn test_valid_create_campaign_flow() {
     let env = Env::default();
     env.mock_all_auths();
@@ -70,8 +123,7 @@ fn test_valid_create_campaign_flow() {
 
     let super_admin = Address::generate(&env);
     let merchant = Address::generate(&env);
-    // let stable_coin_address = Address::generate(&env);
-
+    let recipient = Address::generate(&env);
     let creator = Address::generate(&env);
 
     let (user_registry_address, user_registry) = deploy_user_registry(&env, &super_admin);
@@ -97,11 +149,12 @@ fn test_valid_create_campaign_flow() {
 
     let wasm_hash = env.deployer().upload_contract_wasm(localcoin::WASM);
     let salt = BytesN::from_array(&env, &[2; 32]);
-    let localcoin_address = env.deployer().with_address(super_admin.clone(), salt).deploy(wasm_hash);
-    let localcoin_client = localcoin::Client::new(&env, &localcoin_address);
-    localcoin_client.initialize(&super_admin, &7, &String::from_str(&env, "USDC Coin"), &String::from_str(&env, "USDC"));
-    localcoin_client.mint(&creator, &100);
-    assert_eq!(localcoin_client.balance(&creator), 100);
+    // for test we have deployed localcoin as stable coin
+    let stablecoin_address = env.deployer().with_address(super_admin.clone(), salt).deploy(wasm_hash);
+    let stablecoin_client = localcoin::Client::new(&env, &stablecoin_address);
+    stablecoin_client.initialize(&super_admin, &7, &String::from_str(&env, "USDC Coin"), &String::from_str(&env, "USDC"));
+    stablecoin_client.mint(&creator, &100);
+    assert_eq!(stablecoin_client.balance(&creator), 100);
 
     // initialize issuance management
     issuance_management.initialize(&user_registry_address);
@@ -112,15 +165,15 @@ fn test_valid_create_campaign_flow() {
     issuance_management.set_campaign_management(&campaign_management_address);
 
     // set campaign management in user registry
-    user_registry.set_campaign_managment(&campaign_management_address);
+    user_registry.set_campaign_management(&campaign_management_address);
     assert_eq!(user_registry.get_campaign_management(), campaign_management_address);
 
     // set issuance management in user registry
-    user_registry.set_issuance_managment(&issuance_management_address);
+    user_registry.set_issuance_management(&issuance_management_address);
     assert_eq!(user_registry.get_issuance_management(), issuance_management_address);
 
     // set stable coin address
-    campaign_management.set_stable_coin_address(&localcoin_address);
+    campaign_management.set_stable_coin_address(&stablecoin_address);
 
     let items_associated = vec![&env, String::from_str(&env, "Medicine")];
     let merchants_associated = vec![&env, merchant.clone()];
@@ -137,5 +190,203 @@ fn test_valid_create_campaign_flow() {
     let token_address = token_list.first_unchecked();
 
     campaign_management.create_campaign(&name, &description, &no_of_recipients, &token_address, &amount, &creator);
+    
+    let campaigns = campaign_management.get_campaigns();
 
+    // assert detailes stored in campaign_management
+    let mut campaign_name: Map<Address, String> = Map::new(&env);
+    campaign_name.set(campaigns.first_unchecked(), name.clone());
+
+    assert_eq!(campaign_management.get_campaigns_name(), campaign_name);
+
+    // assert stable coin address
+    assert_eq!(campaign_management.get_stable_coin(), stablecoin_address);
+
+    // assert stable coin of campaign management after campaign creation
+    assert_eq!(campaign_management.get_balance_of_stable_coin(&campaign_management_address), amount);
+
+    // assert all details in new campaign created
+
+    let mut campaign_info: Map<String, Val> = Map::new(&env);
+    campaign_info.set(String::from_str(&env, "name"), name.to_val());
+    campaign_info.set(String::from_str(&env, "description"), description.to_val());
+    campaign_info.set(String::from_str(&env, "no_of_recipients"), no_of_recipients.into());
+    campaign_info.set(String::from_str(&env, "token_address"), token_address.to_val());
+    campaign_info.set(String::from_str(&env, "creator"), creator.to_val());
+    for campaign in campaigns.clone().into_iter() {
+        let camapign_client = campaign_contract::Client::new(&env, &campaign);
+        
+        assert_eq!(camapign_client.get_campaign_info(), campaign_info);
+
+        assert_eq!(camapign_client.get_token_address(), token_address);
+
+        assert_eq!(camapign_client.get_owner(), creator);
+
+        assert_eq!(camapign_client.get_campaign_balance(), amount);
+
+        // now transfer token to recipient
+        camapign_client.transfer_tokens_to_recipient(&recipient, &amount);
+    }
+
+    let token_client = localcoin::Client::new(&env, &token_address);
+    // assert recipient balance before transfer
+    assert_eq!(token_client.balance(&recipient), amount);
+
+    // now recipient transfers the token to merchant
+    token_client.transfer(&recipient, &merchant, &amount);
+
+    // assert recipient balance after transfer
+    assert_eq!(token_client.balance(&recipient), 0);
+
+    // assert merchant balance after it receives token from recipient
+    assert_eq!(token_client.balance(&merchant), amount);
+
+    // assert total supply of token before settelment
+    assert_eq!(token_client.total_supply(), amount);
+
+    // assert stable coin balance of super admin before settelment of a campaign
+    assert_eq!(campaign_management.get_balance_of_stable_coin(&super_admin), 0);
+
+    // now mwechant requests for settelment
+    campaign_management.request_campaign_settelment(&merchant, &amount, &token_address);
+
+    // assert merchant balance after settelment
+    assert_eq!(token_client.balance(&merchant), 0);
+
+    // asert total supply of token after settelment
+    assert_eq!(token_client.total_supply(), 0);
+
+    // assert stable coin balance of campaign management after settelment of a campaign
+    assert_eq!(campaign_management.get_balance_of_stable_coin(&campaign_management_address), 0);
+
+    // assert stable coin balance of super admin before settelment of a campaign
+    assert_eq!(campaign_management.get_balance_of_stable_coin(&super_admin), amount);
+}
+
+#[test]
+#[should_panic(expected = "Invalid token passed in param.")]
+fn test_request_settelment_of_invalid_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let super_admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_address = Address::generate(&env);
+    let amount:i128 = 10;
+
+    let (user_registry_address, _) = deploy_user_registry(&env, &super_admin);
+    let (_, campaign_management) = deploy_campaign_management(&env, &user_registry_address);
+
+    // requests for settelment with invalid token
+    campaign_management.request_campaign_settelment(&merchant, &amount, &token_address);
+}
+
+#[test]
+#[should_panic(expected = "Amount cannot be equal or less than zero.")]
+fn test_request_settelment_of_0_token_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let super_admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_address = Address::generate(&env);
+    let amount:i128 = 0;
+
+    let (user_registry_address, _) = deploy_user_registry(&env, &super_admin);
+    let (_, campaign_management) = deploy_campaign_management(&env, &user_registry_address);
+
+    // requests for settelment with invalid token
+    campaign_management.request_campaign_settelment(&merchant, &amount, &token_address);
+}
+
+#[test]
+#[should_panic(expected = "Amount cannot be equal or less than zero.")]
+fn test_request_settelment_of_negative_token_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let super_admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_address = Address::generate(&env);
+    let amount:i128 = -10;
+
+    let (user_registry_address, _) = deploy_user_registry(&env, &super_admin);
+    let (_, campaign_management) = deploy_campaign_management(&env, &user_registry_address);
+
+    // requests for settelment with invalid token
+    campaign_management.request_campaign_settelment(&merchant, &amount, &token_address);
+}
+
+#[test]
+#[should_panic(expected = "Insufficient token for settelment.")]
+fn test_request_settelment_for_insufficient_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // this test costs more budget than the default allocated so need to set to unlimited
+    env.budget().reset_unlimited();
+
+    let super_admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let amount:i128 = 10;
+    let creator = Address::generate(&env);
+
+    let (user_registry_address, user_registry) = deploy_user_registry(&env, &super_admin);
+    
+    // request merchant registration
+    let proprietor = String::from_str(&env, "Ram");
+    let phone_no = String::from_str(&env, "+977-9841123321");
+    let store_name = String::from_str(&env, "Medical");
+    let location = String::from_str(&env, "Chhauni, Kathmandu");
+    user_registry.merchant_registration(&merchant, &proprietor, &phone_no, &store_name, &location);
+    // verify merchant
+    user_registry.verify_merchant(&merchant);
+
+    assert_eq!(user_registry.get_super_admin(), super_admin);
+
+    assert_eq!(user_registry.get_verified_merchants(), vec![&env, merchant.clone()]);
+
+    // deploy issuance management
+    let wasm_hash = env.deployer().upload_contract_wasm(issuance_management::WASM);
+    let salt = BytesN::from_array(&env, &[1; 32]);
+    let issuance_management_address = env.deployer().with_address(super_admin.clone(), salt).deploy(wasm_hash);
+    let issuance_management = issuance_management::Client::new(&env, &issuance_management_address);
+
+    let wasm_hash = env.deployer().upload_contract_wasm(localcoin::WASM);
+    let salt = BytesN::from_array(&env, &[2; 32]);
+    // for test we have deployed localcoin as stable coin
+    let stablecoin_address = env.deployer().with_address(super_admin.clone(), salt).deploy(wasm_hash);
+    let stablecoin_client = localcoin::Client::new(&env, &stablecoin_address);
+    stablecoin_client.initialize(&super_admin, &7, &String::from_str(&env, "USDC Coin"), &String::from_str(&env, "USDC"));
+    stablecoin_client.mint(&creator, &100);
+    assert_eq!(stablecoin_client.balance(&creator), 100);
+
+    // initialize issuance management
+    issuance_management.initialize(&user_registry_address);
+
+    let (campaign_management_address, campaign_management) = deploy_campaign_management(&env, &user_registry_address);
+
+    // set campaign management in issuance
+    issuance_management.set_campaign_management(&campaign_management_address);
+
+    // set campaign management in user registry
+    user_registry.set_campaign_management(&campaign_management_address);
+    assert_eq!(user_registry.get_campaign_management(), campaign_management_address);
+
+    // set issuance management in user registry
+    user_registry.set_issuance_management(&issuance_management_address);
+    assert_eq!(user_registry.get_issuance_management(), issuance_management_address);
+
+    // set stable coin address
+    campaign_management.set_stable_coin_address(&stablecoin_address);
+
+    let items_associated = vec![&env, String::from_str(&env, "Medicine")];
+    let merchants_associated = vec![&env, merchant.clone()];
+    issuance_management.issue_new_token(&7, &String::from_str(&env, "Token1"), &String::from_str(&env, "TKN1"),
+    &items_associated,  &merchants_associated);
+
+    let token_list = user_registry.get_available_tokens();
+    let token_address = token_list.first_unchecked();
+
+    // requests for settelment with invalid token
+    campaign_management.request_campaign_settelment(&merchant, &amount, &token_address);
 }

--- a/contracts/issuance_management/src/test.rs
+++ b/contracts/issuance_management/src/test.rs
@@ -110,23 +110,8 @@ fn test_valid_complete_flow() {
     let symbol = String::from_str(&env, "TKN1");
 
     issuance_management.issue_new_token(&7, &name, &symbol, &items_associated,  &merchants_associated);
-    // assert_eq!(
-    //     env.auths(),
-    //     std::vec![(
-    //         super_admin.clone(),
-    //         AuthorizedInvocation {
-    //         function: AuthorizedFunction::Contract((
-    //             issuance_management.address.clone(),
-    //             Symbol::new(&env, "issue_new_token"),
-    //             (7_u32, name.clone(), symbol.clone(), 
-    //             items_associated.clone(), merchants_associated.clone()).into_val(&env)
-    //         )),
-    //         sub_invocations: std::vec![]
-    //         }
-    //     )]
-    // );
 
-    let token_address = issuance_management.get_token_address(&String::from_str(&env, "TKN1"));
+    let token_address = issuance_management.get_token_name_address().get_unchecked(String::from_str(&env, "TKN1"));
     assert_eq!(issuance_management.get_items_assocoated(&token_address), items_associated);
 
     assert_eq!(issuance_management.get_merchants_assocoated(&token_address), merchants_associated);
@@ -256,7 +241,7 @@ fn test_non_admin_call_add_token_item() {
     issuance_management.issue_new_token(&7, &String::from_str(&env, "Token3"), &String::from_str(&env, "TKN3"),
     &items_associated,  &merchants_associated);
 
-    let token_address = issuance_management.get_token_address(&String::from_str(&env, "TKN3"));
+    let token_address = issuance_management.get_token_name_address().get_unchecked(String::from_str(&env, "TKN3"));
 
     let new_items_associated = vec![&env, String::from_str(&env, "Food")];
     issuance_management.add_token_items(&token_address, &new_items_associated);
@@ -329,7 +314,7 @@ fn test_add_duplicate_item() {
     issuance_management.issue_new_token(&7, &String::from_str(&env, "Token4"), &String::from_str(&env, "TKN4"),
     &items_associated,  &merchants_associated);
 
-    let token_address = issuance_management.get_token_address(&String::from_str(&env, "TKN4"));
+    let token_address = issuance_management.get_token_name_address().get_unchecked(String::from_str(&env, "TKN4"));
 
     // try to add already existing item
     let new_items_associated = vec![&env, String::from_str(&env, "Medicine")];
@@ -356,7 +341,7 @@ fn test_non_admin_call_add_token_merchant() {
     issuance_management.issue_new_token(&7, &String::from_str(&env, "Token5"), &String::from_str(&env, "TKN5"),
     &items_associated,  &merchants_associated);
 
-    let token_address = issuance_management.get_token_address(&String::from_str(&env, "TKN5"));
+    let token_address = issuance_management.get_token_name_address().get_unchecked(String::from_str(&env, "TKN5"));
 
     let new_merchant_list = vec![&env, merchant];
     issuance_management.add_token_merchants(&token_address, &new_merchant_list);
@@ -411,7 +396,7 @@ fn test_add_duplicate_merchant() {
     issuance_management.issue_new_token(&7, &String::from_str(&env, "Token6"), &String::from_str(&env, "TKN6"),
     &items_associated,  &merchants_associated);
 
-    let token_address = issuance_management.get_token_address(&String::from_str(&env, "TKN6"));
+    let token_address = issuance_management.get_token_name_address().get_unchecked(String::from_str(&env, "TKN6"));
 
     // try to add already existing merchant
     let new_merchant = vec![&env, merchant];

--- a/contracts/localcoin/src/contract.rs
+++ b/contracts/localcoin/src/contract.rs
@@ -111,7 +111,7 @@ impl LocalCoin {
         let issuance_client = issuance::Client::new(&e, &issuance_addr);
         
         let merchants_associated = issuance_client.get_merchants_assocoated(&current_contract);
-        if !merchants_associated.contains(to.clone()) {
+        if !(merchants_associated.contains(to.clone())) {
             panic!("This token's item is not accepted by the merchant.")
         }
         Self::transfer(e, from, to, amount);

--- a/contracts/localcoin/src/lib.rs
+++ b/contracts/localcoin/src/lib.rs
@@ -5,3 +5,6 @@ mod balance;
 mod contract;
 mod metadata;
 mod storage_types;
+mod test;
+
+pub use crate::contract::LocalCoinClient;

--- a/contracts/localcoin/src/test.rs
+++ b/contracts/localcoin/src/test.rs
@@ -1,0 +1,181 @@
+#![cfg(test)]
+extern crate std;
+
+use crate::{contract::LocalCoin, LocalCoinClient};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+    Address, Env, IntoVal
+};
+
+fn create_token<'a>(e: &Env, admin: &Address) -> LocalCoinClient<'a> {
+    let token = LocalCoinClient::new(e, &e.register_contract(None, LocalCoin {}));
+    token.initialize(admin, &7, &"name".into_val(e), &"symbol".into_val(e));
+    token
+}
+
+#[test]
+fn test() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin1 = Address::generate(&e);
+    let admin2 = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let user2 = Address::generate(&e);
+    let token = create_token(&e, &admin1);
+
+    token.mint(&user1, &1000);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            admin1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("mint"),
+                    (&user1, 1000_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.balance(&user1), 1000);
+    assert_eq!(token.total_supply(), 1000);
+    assert_eq!(token.total_burned(), 0);
+
+    token.transfer(&user1, &user2, &600);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("transfer"),
+                    (&user1, &user2, 600_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.balance(&user1), 400);
+    assert_eq!(token.balance(&user2), 600);
+
+    token.set_admin(&admin2);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            admin1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("set_admin"),
+                    (&admin2,).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+}
+
+#[test]
+fn test_burn() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.mint(&user1, &1000);
+    assert_eq!(token.balance(&user1), 1000);
+    assert_eq!(token.total_supply(), 1000);
+    assert_eq!(token.total_burned(), 0);
+
+    token.burn(&user1, &1000);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("burn"),
+                    (&user1, 1000_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+
+    assert_eq!(token.balance(&user1), 0);
+    assert_eq!(token.total_supply(), 0);
+    assert_eq!(token.total_burned(), 1000);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn transfer_insufficient_balance() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let user2 = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.mint(&user1, &1000);
+    assert_eq!(token.balance(&user1), 1000);
+
+    token.transfer(&user1, &user2, &1001);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn initialize_already_initialized() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.initialize(&admin, &10, &"name".into_val(&e), &"symbol".into_val(&e));
+}
+
+#[test]
+fn test_set_issuance_management() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let issuance_management = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.set_issuance_management(&issuance_management);
+    assert_eq!(token.get_issuance_management(), issuance_management);
+
+}
+
+#[test]
+#[should_panic(expected = "Address already set.")]
+fn test_set_already_set_issuance_management() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let issuance_management = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.set_issuance_management(&issuance_management);
+    token.set_issuance_management(&issuance_management);
+
+}
+
+#[test]
+#[should_panic(expected = "Decimal must fit in a u8")]
+fn decimal_is_over_max() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let token = LocalCoinClient::new(&e, &e.register_contract(None, LocalCoin {}));
+    token.initialize(
+        &admin,
+        &(u32::from(u8::MAX) + 1),
+        &"name".into_val(&e),
+        &"symbol".into_val(&e),
+    );
+}

--- a/contracts/user_registry/src/lib.rs
+++ b/contracts/user_registry/src/lib.rs
@@ -77,7 +77,7 @@ impl UserRegisrty {
         super_admin.require_auth();
 
         let key = DataKeys::MerchantsInfo(merchant_addr.clone());
-        if !env.storage().instance().has(&key) {
+        if !(env.storage().instance().has(&key)) {
             panic!("No registration request.")
         }
 


### PR DESCRIPTION
This PR contains additional test case for campaign management contracts and it also fixes all tests. 
This updates get_campaign_info and get_creator_campaigns api return values to dict.